### PR TITLE
Fixed duration messages

### DIFF
--- a/src/main/java/com/connorlinfoot/actionbarapi/ActionBarAPI.java
+++ b/src/main/java/com/connorlinfoot/actionbarapi/ActionBarAPI.java
@@ -81,16 +81,15 @@ public class ActionBarAPI extends JavaPlugin {
             }.runTaskLater(plugin, duration + 1);
         }
 
-        // Re-sends the messages every 3 seconds so it doesn't go away from the player's screen.
-        while (duration > 60) {
-            duration -= 60;
-            int sched = duration % 60;
+        // Re-sends the messages every 2 seconds so it doesn't go away from the player's screen.
+        while (duration > 40) {
+            duration -= 40;
             new BukkitRunnable() {
                 @Override
                 public void run() {
                     sendActionBar(player, message);
                 }
-            }.runTaskLater(plugin, (long) sched);
+            }.runTaskLater(plugin, duration);
         }
     }
 


### PR DESCRIPTION
- 3 seconds repeating is not fast enough (message is fading out after about 2 seconds), above that 2 seconds are more accurate
- int sched = duration % 60; - it didn't make sense
